### PR TITLE
fix(rateLimiter): Centralize rate limiter init (Redis + in-memory)

### DIFF
--- a/app/api/describe.py
+++ b/app/api/describe.py
@@ -4,24 +4,17 @@ import re
 import structlog
 from fastapi import APIRouter, Body, File, UploadFile, Depends, Request, HTTPException
 from fastapi.responses import JSONResponse
-from fastapi_limiter.depends import RateLimiter
-from pyrate_limiter import Duration, Limiter, Rate
 
-from ..config import settings
 from ..services import captioning
-from ..dependencies import in_memory_rate_limiter
+from ..dependencies import rate_limiter_dependency
 from ..state import state
 
 logger = structlog.get_logger(__name__)
 
-limiter_dependency = RateLimiter(
-    limiter=Limiter(Rate(settings.RATE_LIMIT_TIMES, settings.RATE_LIMIT_SECONDS * Duration.SECOND))
-) if settings.REDIS_ENABLED else in_memory_rate_limiter
-
 router = APIRouter(
     prefix="/api/v1/describe",
     tags=["Describe"],
-    dependencies=[Depends(limiter_dependency)]
+    dependencies=[Depends(rate_limiter_dependency)]
 )
 
 DATA_URL_PATTERN = re.compile(r"^data:(image/[a-z0-9.+-]+);base64,(.+)$", re.IGNORECASE)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,29 +1,63 @@
 import time
+from typing import List, Optional
+
 import structlog
-from fastapi import Request, HTTPException, Header
+from fastapi import Request, Response, HTTPException, Header
 from starlette.middleware.base import BaseHTTPMiddleware
-from cachetools import TTLCache
-from typing import Optional
+from pyrate_limiter import BucketAsyncWrapper, Duration, InMemoryBucket, Limiter, Rate, RedisBucket
+from redis.asyncio import Redis
+from fastapi_limiter.depends import RateLimiter
 
 from .config import settings
 from .metrics import HTTP_REQUESTS_TOTAL, HTTP_REQUEST_LATENCY_SECONDS
+from .state import state
 
 logger = structlog.get_logger(__name__)
 
-# In-memory cache for rate limiting when Redis is disabled
-# 10,000 max clients, 5-second time-to-live window
-ttl_cache = TTLCache(maxsize=10000, ttl=settings.RATE_LIMIT_SECONDS)
+RATE_LIMIT_BUCKET_KEY = "describe-api-rate-limit"
 
 
-def in_memory_rate_limiter(request: Request):
-    """A simple in-memory rate limiter for use when Redis is disabled."""
-    if not settings.REDIS_ENABLED:
-        ip = request.client.host
-        count = ttl_cache.get(ip, 0) + 1
-        ttl_cache[ip] = count
-        if count > settings.RATE_LIMIT_TIMES:
-            logger.warning("in_memory_rate_limit_exceeded", client_ip=ip, count=count)
-            raise HTTPException(status_code=429, detail="Too Many Requests")
+def _rates() -> List[Rate]:
+    return [Rate(settings.RATE_LIMIT_TIMES, settings.RATE_LIMIT_SECONDS * Duration.SECOND)]
+
+
+def build_in_memory_rate_limiter() -> RateLimiter:
+    """
+    Per-instance limiter. Used when REDIS_ENABLED=False, and also as the
+    fallback if the Redis-backed limiter fails to come up at startup.
+
+    InMemoryBucket is sync-only, so it's wrapped in BucketAsyncWrapper -- the
+    fastapi-limiter RateLimiter dependency always calls try_acquire_async.
+    """
+    bucket = BucketAsyncWrapper(InMemoryBucket(_rates()))
+    return RateLimiter(limiter=Limiter(bucket))
+
+
+async def build_redis_rate_limiter(redis_client: Redis) -> RateLimiter:
+    """
+    Cross-instance limiter, sharing state across every app replica via Redis.
+    RedisBucket.init() is a classmethod that must be awaited when given an
+    async redis client (redis.asyncio.Redis) -- this is what actually wires
+    the limiter up to Redis, which the old code never did.
+    """
+    bucket = await RedisBucket.init(_rates(), redis_client, RATE_LIMIT_BUCKET_KEY)
+    return RateLimiter(limiter=Limiter(bucket))
+
+
+async def rate_limiter_dependency(request: Request, response: Response):
+    """
+    The single rate-limiting dependency every router should depend on.
+
+    state.rate_limiter is built exactly once, during app startup (see
+    app/lifespan.py), via build_redis_rate_limiter() or
+    build_in_memory_rate_limiter() above. This function just delegates to
+    whichever one startup built -- there is exactly one place in the app that
+    constructs a rate limiter, and exactly one dependency that uses it.
+    """
+    if state.rate_limiter is None:
+        logger.error("rate_limiter_not_initialized")
+        raise HTTPException(status_code=503, detail="Service Unavailable: Rate limiter not initialized.")
+    return await state.rate_limiter(request, response)
 
 
 async def verify_metrics_api_key(authorization: Optional[str] = Header(None)):

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -6,7 +6,6 @@ from fastapi import Request, Response, HTTPException, Header
 from starlette.middleware.base import BaseHTTPMiddleware
 from pyrate_limiter import BucketAsyncWrapper, Duration, InMemoryBucket, Limiter, Rate, RedisBucket
 from redis.asyncio import Redis
-from fastapi_limiter.depends import RateLimiter
 
 from .config import settings
 from .metrics import HTTP_REQUESTS_TOTAL, HTTP_REQUEST_LATENCY_SECONDS
@@ -21,43 +20,30 @@ def _rates() -> List[Rate]:
     return [Rate(settings.RATE_LIMIT_TIMES, settings.RATE_LIMIT_SECONDS * Duration.SECOND)]
 
 
-def build_in_memory_rate_limiter() -> RateLimiter:
-    """
-    Per-instance limiter. Used when REDIS_ENABLED=False, and also as the
-    fallback if the Redis-backed limiter fails to come up at startup.
-
-    InMemoryBucket is sync-only, so it's wrapped in BucketAsyncWrapper -- the
-    fastapi-limiter RateLimiter dependency always calls try_acquire_async.
-    """
+def build_in_memory_rate_limiter() -> Limiter:
+    """Per-instance limiter. Used when REDIS_ENABLED=False, and as the
+    fallback if the Redis-backed limiter fails to come up at startup."""
     bucket = BucketAsyncWrapper(InMemoryBucket(_rates()))
-    return RateLimiter(limiter=Limiter(bucket))
+    return Limiter(bucket)
 
 
-async def build_redis_rate_limiter(redis_client: Redis) -> RateLimiter:
-    """
-    Cross-instance limiter, sharing state across every app replica via Redis.
-    RedisBucket.init() is a classmethod that must be awaited when given an
-    async redis client (redis.asyncio.Redis) -- this is what actually wires
-    the limiter up to Redis, which the old code never did.
-    """
+async def build_redis_rate_limiter(redis_client: Redis) -> Limiter:
+    """Cross-instance limiter, sharing state across every app replica via Redis."""
     bucket = await RedisBucket.init(_rates(), redis_client, RATE_LIMIT_BUCKET_KEY)
-    return RateLimiter(limiter=Limiter(bucket))
+    return Limiter(bucket)
 
 
 async def rate_limiter_dependency(request: Request, response: Response):
-    """
-    The single rate-limiting dependency every router should depend on.
-
-    state.rate_limiter is built exactly once, during app startup (see
-    app/lifespan.py), via build_redis_rate_limiter() or
-    build_in_memory_rate_limiter() above. This function just delegates to
-    whichever one startup built -- there is exactly one place in the app that
-    constructs a rate limiter, and exactly one dependency that uses it.
-    """
+    """The single rate-limiting dependency every router should depend on."""
     if state.rate_limiter is None:
         logger.error("rate_limiter_not_initialized")
         raise HTTPException(status_code=503, detail="Service Unavailable: Rate limiter not initialized.")
-    return await state.rate_limiter(request, response)
+
+    key = f"{request.client.host}:{request.url.path}"
+    success = await state.rate_limiter.try_acquire_async(key, blocking=False)
+    if not success:
+        logger.warning("rate_limit_exceeded", client_ip=request.client.host, path=request.url.path)
+        raise HTTPException(status_code=429, detail="Too Many Requests")
 
 
 async def verify_metrics_api_key(authorization: Optional[str] = Header(None)):

--- a/app/lifespan.py
+++ b/app/lifespan.py
@@ -7,11 +7,10 @@ import structlog
 from fastapi import FastAPI
 from aiokafka import AIOKafkaProducer
 from redis.asyncio import Redis
-from fastapi_limiter.depends import RateLimiter
-
 
 from .config import settings
 from .background.kafka_consumer import consume_kafka_requests
+from .dependencies import build_in_memory_rate_limiter, build_redis_rate_limiter
 from .state import state
 
 logger = structlog.get_logger(__name__)
@@ -53,14 +52,18 @@ async def _startup():
             logger.error("kafka_initialization_failed", error=str(e), exc_info=True)
 
     if settings.REDIS_ENABLED:
-        logger.info("redis_enabled_initializing_rate_limiter")
         try:
-            state.redis_client = Redis.from_url(settings.REDIS_URL, encoding="utf-8", decode_responses=True)
-            await RateLimiter.init(state.redis_client)
-            logger.info("fastapi_limiter_initialized_successfully")
+            state.redis_client = Redis.from_url(settings.REDIS_URL)
+            await state.redis_client.ping()
+            state.rate_limiter = await build_redis_rate_limiter(state.redis_client)
+            logger.info("redis_client_initialized_successfully")
         except Exception as e:
-            logger.error("fastapi_limiter_initialization_failed", error=str(e), exc_info=True)
+            logger.error("redis_client_initialization_failed", error=str(e), exc_info=True)
             state.redis_client = None
+            state.rate_limiter = build_in_memory_rate_limiter()
+            logger.warning("rate_limiter_falling_back_to_in_memory")
+    else:
+        state.rate_limiter = build_in_memory_rate_limiter()
 
 
 async def _shutdown():

--- a/app/state.py
+++ b/app/state.py
@@ -15,6 +15,7 @@ class AppState:
         self.kafka_producer: Optional[AIOKafkaProducer] = None
         self.kafka_consumer_task: Optional[asyncio.Task] = None
         self.redis_client: Optional[Redis] = None
+        self.rate_limiter: Optional[RateLimiter] = None
 
 
 state = AppState()

--- a/app/state.py
+++ b/app/state.py
@@ -4,6 +4,7 @@ import onnxruntime as ort
 import tiktoken
 from aiokafka import AIOKafkaProducer
 from redis.asyncio import Redis
+from pyrate_limiter import Limiter
 
 
 class AppState:
@@ -15,7 +16,7 @@ class AppState:
         self.kafka_producer: Optional[AIOKafkaProducer] = None
         self.kafka_consumer_task: Optional[asyncio.Task] = None
         self.redis_client: Optional[Redis] = None
-        self.rate_limiter: Optional[RateLimiter] = None
+        self.rate_limiter: Optional[Limiter] = None
 
 
 state = AppState()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ autopep8==2.3.2
 httpx2==2.4.0
 pydantic-settings==2.14.2
 redis==8.0.0
-fastapi-limiter==0.2.0
+pyrate-limiter==4.4.0
 prometheus-client==0.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ flake8==7.3.0
 autopep8==2.3.2
 httpx2==2.4.0
 pydantic-settings==2.14.2
-cachetools==7.1.4
 redis==8.0.0
 fastapi-limiter==0.2.0
 prometheus-client==0.25.0


### PR DESCRIPTION
Initialize a single startup-built RateLimiter (Redis-backed when available, fallback to in-memory). Add rate_limiter dependency and store in state. Wire router to use centralized dependency and remove cachetools.